### PR TITLE
🔨 refactor : cron 작업 위치 이동, postImage 생성으로 인한 로직 변경경

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -25,6 +25,7 @@ import { ScheduleModule } from '@nestjs/schedule';
 import { ApplicationAttachmentsModule } from './application-attachments/application-attachments.module';
 import { ApplicationAttachment } from './application-attachments/entities/application-attachment.entity';
 import { PostImages } from './attachments/entities/post-images.entity';
+import { BatchModule } from './batch/batch.module';
 
 
 @Module({
@@ -69,6 +70,7 @@ import { PostImages } from './attachments/entities/post-images.entity';
     UsersModule,
     AuthModule,
     EmailModule,
+    BatchModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/api/src/application-attachments/application-attachments.controller.ts
+++ b/api/src/application-attachments/application-attachments.controller.ts
@@ -15,7 +15,7 @@ export class ApplicationAttachmentsController {
   @ApiResponse({
     example:{
       message:'해당 신청의 파일을 불러왔습니다.',
-      file:{
+      files:{
         id:'number',
         applicationId:'number',
         filename:'string',
@@ -25,10 +25,10 @@ export class ApplicationAttachmentsController {
     }
   })
   @Get(':id')
-  async getOne(@Param() id:number){
+  async getFiles(@Param() id:number){
     return {
       message:'해당 신청의 파일을 불러왔습니다.',
-      file:await this.applicationAttachmentsService.findByApplication(id)
+      files:await this.applicationAttachmentsService.findByApplication(id)
     }
   }
 

--- a/api/src/application-attachments/application-attachments.service.ts
+++ b/api/src/application-attachments/application-attachments.service.ts
@@ -3,7 +3,7 @@ import { Multer } from 'multer';
 import { transactional } from 'src/common/utils/transaction-helper';
 import { DataSource, QueryRunner } from 'typeorm';
 import { ApplicationAttachment } from './entities/application-attachment.entity';
-import { error } from 'console';
+import * as fs from 'fs'
 
 @Injectable()
 export class ApplicationAttachmentsService {
@@ -25,7 +25,7 @@ export class ApplicationAttachmentsService {
   }
   
   async deleteOne(id:number){
-    transactional(this.datasource,async queryRunner=>{
+    await transactional(this.datasource,async queryRunner=>{
       await queryRunner.manager.delete(ApplicationAttachment,id)
     })
   }
@@ -33,6 +33,8 @@ export class ApplicationAttachmentsService {
   async deleteByApplication(filenames:string[],queryRunner:QueryRunner){
     filenames.forEach(async filename=>{
       await queryRunner.manager.delete(ApplicationAttachment,{filename})
+      fs.unlink(filename,e=>console.log(e))
     })
+    
   }
 }

--- a/api/src/application-form/application-form.controller.ts
+++ b/api/src/application-form/application-form.controller.ts
@@ -30,7 +30,7 @@ export class ApplicationFormController {
     schema:{
       type:'object',
       properties:{
-        file:{
+        files:{
           type:'string',
           format:'binary',
           description:'입학 신청서류'
@@ -46,7 +46,7 @@ export class ApplicationFormController {
     }
   })
   @Post()
-  @UseInterceptors(FilesInterceptor('file',10,FileDiskOptions))
+  @UseInterceptors(FilesInterceptor('files',10,FileDiskOptions))
   async createApplication(
     @Body() CreateApplicationFormDto:CreateApplicationFormDto,
     @UploadedFiles() files:Express.Multer.File[]
@@ -98,7 +98,7 @@ export class ApplicationFormController {
     schema:{
       type:'object',
       properties:{
-        file:{
+        files:{
           type:'string',
           format:'binary',
           description:'새로 추가하는 입학 신청서류, 서류가 없을 경우 필수 아님'
@@ -114,7 +114,7 @@ export class ApplicationFormController {
     example:{message:'입학 신청이 수정되었습니다.'}
   })
   @Patch(':id')
-  @UseInterceptors(FilesInterceptor('file',10,FileDiskOptions))
+  @UseInterceptors(FilesInterceptor('files',10,FileDiskOptions))
   async updateApplication(
     @Param('id') id:number,
     @UploadedFiles() files:Express.Multer.File[], // 새로 추가되는 파일만 받음

--- a/api/src/application-form/application-form.service.ts
+++ b/api/src/application-form/application-form.service.ts
@@ -36,7 +36,7 @@ export class ApplicationFormService {
     const [value,total]= await queryRunner.getManyAndCount()
 
     if(total==0){
-      throw new BadRequestException(`미해결 입학신청이 존재하지 않습니다`)
+      return {message:`미해결 입학신청이 존재하지 않습니다`}
     }
 
     const totalPage = Math.ceil(total / take);

--- a/api/src/application-form/entities/application-form.entity.ts
+++ b/api/src/application-form/entities/application-form.entity.ts
@@ -14,5 +14,5 @@ export class ApplicationForm {
     @Column({default:false})
     isDone:boolean
     @OneToMany(()=>ApplicationAttachment,(attachment)=>attachment.applicationId,{onDelete:'CASCADE'})
-    applicationAttchment:ApplicationAttachment[]
+    applicationAttachment:ApplicationAttachment[]
 }

--- a/api/src/attachments/attachments.controller.ts
+++ b/api/src/attachments/attachments.controller.ts
@@ -2,18 +2,10 @@ import {
   Controller,
   Post,
   Param,
-  Delete,
-  Query,
   Res,
   UseInterceptors,
   UploadedFile,
-  NotFoundException,
-  HttpException,
-  HttpStatus,
   Get,
-  Body,
-  Put,
-  Patch,
 } from '@nestjs/common';
 import { Response } from 'express';
 import { AttachmentsService } from './attachments.service';
@@ -26,9 +18,6 @@ import {
   ApiParam,
   ApiResponse,
 } from '@nestjs/swagger';
-import { FileDiskOptions } from 'src/common/multer-fileDiskOptions';
-import { Cron } from '@nestjs/schedule';
-import { CreateApplicationFormDto } from 'src/application-form/dto/create-application-form.dto';
 
 @Controller('attachments')
 export class AttachmentsController {
@@ -71,7 +60,7 @@ export class AttachmentsController {
   })
   @ApiResponse({
     example: {
-      download: 'files',
+      download: 'file',
     },
   })
   @Get(':filename') //다운로드
@@ -80,11 +69,6 @@ export class AttachmentsController {
     @Param('filename') filename: string,
   ) {
     return res.download(`/files/${filename}`);
-  }
-
-  @Cron('0 0 4 * * 4') // 목요일 4시에 작동
-  async deleteRestedFiles() {
-    await this.attachmentsService.deleteNotUsedFiles();
   }
 
 }

--- a/api/src/attachments/attachments.service.ts
+++ b/api/src/attachments/attachments.service.ts
@@ -1,5 +1,4 @@
 import {
-  BadRequestException,
   HttpException,
   HttpStatus,
   Injectable,
@@ -8,14 +7,7 @@ import {
 import { DataSource, QueryRunner } from 'typeorm';
 import { Attachment } from './entities/attachment.entity';
 import * as fs from 'fs';
-import * as path from 'path';
-import { transactional } from 'src/common/utils/transaction-helper';
-import { Banner } from 'src/banners/entities/banner.entity';
-import { Post } from 'src/posts/entities/post.entity';
-import { ApplicationAttachment } from 'src/application-attachments/entities/application-attachment.entity';
 import { PostImages } from './entities/post-images.entity';
-import { now } from 'moment';
-import { findFiles } from 'src/common/fileArrayFind';
 
 @Injectable()
 export class AttachmentsService {
@@ -29,7 +21,7 @@ export class AttachmentsService {
   ) {
     for (let file of files) {
       await queryRunner.manager.save(PostImages, {
-        postId: postId,
+        postId,
         filename: file.filename,
         fileSize: file.size,
       });
@@ -50,13 +42,13 @@ export class AttachmentsService {
       });
     }
   }
-
-  async deleteOldImage(files: Express.Multer.File[], queryRunner: QueryRunner) {
-    for (let file of files) {
+  
+  async deleteOldImage(filesnames: string[], queryRunner: QueryRunner) {
+    for (let filename of filesnames) {
       await queryRunner.manager.delete(PostImages, {
-        filename: file.filename,
+        filename
       });
-      const filePath = `/files/${file.filename}`;
+      const filePath = `/files/${filename}`;
       if (!fs.existsSync(filePath)) {
         throw new NotFoundException('파일을 찾을 수 없습니다.');
       }
@@ -86,75 +78,9 @@ export class AttachmentsService {
       if (!fs.existsSync(filePath)) {
         throw new NotFoundException('파일을 찾을 수 없습니다.');
       }
-      fs.unlink(filePath, (error) => {
-        if (error) {
-          throw new HttpException(
-            '파일 삭제 중 오류가 발생했습니다.',
-            HttpStatus.INTERNAL_SERVER_ERROR,
-          );
-        }
-      });
+      fs.unlink(filePath,e=>console.log(e))
     }
     return { message: '파일이 성공적으로 삭제되었습니다.' };
   }
 
-  async deleteNotUsedFiles() {
-    const storedFiles = fs.readdirSync(`/files`);
-
-    const [
-      usedFilesAttachments,
-      usedFilesBanner,
-      usedFilesApplicationAttachment,
-      usedFilesPost,
-      usedFilesPostImages,
-    ] = await Promise.all([
-      this.dataSource.manager.find(Attachment, { select: ['filename'] }),
-      this.dataSource.manager.find(Banner, { select: ['image'] }),
-      this.dataSource.manager.find(ApplicationAttachment, {
-        select: ['filename'],
-      }),
-      this.dataSource.manager.find(Post, { select: ['content'] }),
-      this.dataSource.manager.find(PostImages, { select: ['filename'] }),
-    ]); //join 해서 받아오기
-    const regex = /<img[^>]+src=["']?([^"'\s>]+)["'\s>]/g;
-    const SrcList = [
-      ...usedFilesApplicationAttachment.map((item) => {
-        return item.filename;
-      }),
-      ...usedFilesAttachments.map((item) => {
-        return item.filename;
-      }),
-      ...usedFilesBanner.map((item) => {
-        return item.image;
-      }),
-      ...usedFilesPostImages.map((item) => {
-        return item.filename;
-      }),
-    ];
-    let match;
-
-    usedFilesPost.map((item) => {
-      while ((match = regex.exec(item.content)) !== null) {
-        if (!(match[1][0] === 'd')) {
-          // 인코딩 되어 데이터 자체가 들어간 img를 제외
-          SrcList.push(match[1].replace(`${process.env.BACKEND_URL}/`, ''));
-          // // 정규식으로 찾아 추출한 문자열이 1번 인덱스에 저장, 백엔드 주소 제거해서 SrcList에 저장
-        }
-      }
-    });
-    //SrcList 에 사용된 src속성의 파일이름들을 저장
-
-    const deleteFiles = storedFiles.filter((item) => !SrcList.includes(item));
-    try {
-      deleteFiles.map((item) => {
-        fs.unlinkSync(`/files/${item}`);
-      });
-      const deletedFile = deleteFiles.join('\t');
-      const restoreRow = `[${new Date().getDate()}]` + deletedFile;
-      fs.appendFileSync('/cron_delete.txt', restoreRow + `\n`);
-    } catch (e) {
-      console.log(e);
-    }
-    //삭제된 파일명 저장해두는 파일 만들기
-  }
 }

--- a/api/src/batch/batch.controller.ts
+++ b/api/src/batch/batch.controller.ts
@@ -1,0 +1,13 @@
+import { Controller } from '@nestjs/common';
+import { BatchService } from './batch.service';
+import { Cron } from '@nestjs/schedule';
+
+@Controller('batch')
+export class BatchController {
+  constructor(private readonly batchService: BatchService) {}
+
+  @Cron('0 0 4 * * 4') // 목요일 4시에 작동
+    async deleteRestedFiles() {
+      await this.batchService.deleteNotUsedFiles();
+    }
+}

--- a/api/src/batch/batch.module.ts
+++ b/api/src/batch/batch.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { BatchService } from './batch.service';
+import { BatchController } from './batch.controller';
+
+@Module({
+  controllers: [BatchController],
+  providers: [BatchService],
+})
+export class BatchModule {}

--- a/api/src/batch/batch.service.ts
+++ b/api/src/batch/batch.service.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@nestjs/common';
+import * as fs from 'fs'
+import { DataSource } from 'typeorm';
+import { Banner } from 'src/banners/entities/banner.entity';
+import { Attachment } from 'src/attachments/entities/attachment.entity';
+import { ApplicationAttachment } from 'src/application-attachments/entities/application-attachment.entity';
+import { PostImages } from 'src/attachments/entities/post-images.entity';
+
+@Injectable()
+export class BatchService {
+    constructor(private readonly dataSource:DataSource){}
+
+     async deleteNotUsedFiles() {
+        const storedFilesInServer = fs.readdirSync(`/files`);
+        //서버에 저장되어있는 파일 이름들 
+    
+        const [
+          usedFilesAttachments,
+          usedFilesBanner,
+          usedFilesApplicationAttachment,
+          usedFilesPostImages,
+        ] = await Promise.all([
+          this.dataSource.manager.find(Attachment, { select: ['filename'] }),
+          this.dataSource.manager.find(Banner, { select: ['image'] }),
+          this.dataSource.manager.find(ApplicationAttachment, { select: ['filename'] }),
+          this.dataSource.manager.find(PostImages, { select: ['filename'] }),
+        ]);// 파일 데이터를 저장한 테이블들에서 파일 이름 열을 다 받아옴
+
+        const SrcList = [
+          ...usedFilesApplicationAttachment.map((item) => {
+            return item.filename;
+          }),
+          ...usedFilesAttachments.map((item) => {
+            return item.filename;
+          }),
+          ...usedFilesBanner.map((item) => {
+            return item.image;
+          }),
+          ...usedFilesPostImages.map((item) => {
+            return item.filename;
+          }),
+        ];//[{filename:'파일이름'}] 형태에서 '파일이름'만 빼서 새로운 배열에 저장
+
+        const deleteFiles = storedFilesInServer.filter((item) => !SrcList.includes(item));
+        // 서버에 저장된 파일 중에 사용되고 있는 파일을 제외하고 사용되지 않는 파일들의 배열을 생성
+
+        const CheckNotDeleted=[]
+        deleteFiles.map((item) => {
+          try {
+            fs.unlinkSync(`/files/${item}`)
+          } catch (e) {
+            CheckNotDeleted.push(item)
+          } finally{
+            console.log(CheckNotDeleted)
+          }
+          
+        });
+        // 각 파일 삭제
+      }
+}

--- a/api/src/common/fileArrayFind.ts
+++ b/api/src/common/fileArrayFind.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import * as mime from 'mime-types'
+import { NotFoundException } from '@nestjs/common'
 /**
  * 
  * @param files //파일 이름을 배열형태로 
@@ -9,13 +10,19 @@ import * as mime from 'mime-types'
 export function findFiles(files:string[]){ // 파일 이름을 string 배열로 받기 
     let FilesMetaData=[]
     files.forEach(file=>{
-        FilesMetaData.push(
-            {
-                size:fs.statSync(`/files/${file}`).size,
-                filename:file,
-                mimetype:mime.lookup(path.extname(`/files/${file}`))
-            }
+        try {
+            const fileData=fs.statSync(`/files/${file}`)
+            FilesMetaData.push(
+                {
+                    size:fileData.size,
+                    filename:file,
+                    mimetype:mime.lookup(path.extname(file))
+                }
         )
+        } catch (e) {
+            throw new NotFoundException({message:`'${file}' 파일이 서버에 저장되어있지 않습니다.`})
+        }
+        
     })
     
     return FilesMetaData

--- a/api/src/posts/posts.controller.ts
+++ b/api/src/posts/posts.controller.ts
@@ -227,7 +227,7 @@ export class PostsController {
     schema: {
       type: 'object',
       properties: {
-        file:{type:'string',format:'binary',description:'글의 첨부파일 전부, 없을 경우 필수 아님'},
+        files:{type:'string',format:'binary',description:'글의 첨부파일 전부, 없을 경우 필수 아님'},
         category: { type: 'string', description:'글의 카테고리, 필수' },
         title: { type: 'string', description:'글의 제목, 필수' },
         content: { type: 'string', description:'글의 내용, 필수' },
@@ -240,7 +240,7 @@ export class PostsController {
     example: { message: '글이 작성되었습니다.' },
   })
   @Post() //완료
-  @UseInterceptors(FilesInterceptor('file',10,FileDiskOptions))
+  @UseInterceptors(FilesInterceptor('files',10,FileDiskOptions))
   async create(
     @Body() createPostDto: CreatePostDto,
     @UploadedFiles() files:Express.Multer.File[]
@@ -256,7 +256,7 @@ export class PostsController {
     schema: {
       type: 'object',
       properties: {
-        file:{type:'string',format:'binary',description:'새로 추가하는 첨부파일'},
+        files:{type:'string',format:'binary',description:'새로 추가하는 첨부파일'},
         category: { type: 'string', description:'글의 카테고리, 필수 아님' },
         title: { type: 'string', description:'글의 제목, 필수 아님' },
         content: { type: 'string', description:'글의 내용, 필수 아님' },
@@ -274,7 +274,7 @@ export class PostsController {
     example: { message: '글이 수정되었습니다.' },
   })
   @Patch(':id')
-  @UseInterceptors(FilesInterceptor('file',10,FileDiskOptions))
+  @UseInterceptors(FilesInterceptor('files',10,FileDiskOptions))
   async update(@Param('id') id: number, @Body() updatePostDto: UpdatePostDto,@UploadedFiles() files:Express.Multer.File[]) {
     await this.postsService.update(id, updatePostDto,files);
     return { message: '글이 수정되었습니다.' };


### PR DESCRIPTION
## 🔍 이 PR로 해결하고자 하는 문제는 무엇인가요?

> #37 #36 #35 #34 

## ✨ 이 PR로 주요하게 바뀐 점은 무엇인가요?

> 문제를 해결하면서 주요 변경 사항을 작성해주세요.

- 파일 업로드 받는 API들에서 속성 이름을 file 에서 files로 변경
- 입학 신청을 불러올때 값이 없으면 에러가 뜨는 걸 return 으로 변경
- attachment 모듈에서 작동하던 cron 작업을 batch 모듈로 이동
- 글 내부의 이미지 파일을 관리하는 PostImage 테이블의 생성으로 본래 정규식으로 가져오던 로직을 PostImage 테이블을 참조하도록 변경

## 🔖 주요 변경 사항 외에 추가로 변경된 부분이 있나요?

> 없으면 "없음"이라고 작성해주세요.

- ApplicationAttachment Controller에서 입학신청의 첨부파일을 받아오는 함수를 getOne 에서 getFiles로 변경

## 🖥 작동하는 모습

> 스크린샷이나 녹화된 비디오, 또는 gif를 추가해서, 리뷰어가 변경점을 이해하는 데 도움이 되도록 해주세요.
